### PR TITLE
Generate an app cache on build, part 1 of app offlining

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -384,6 +384,23 @@ module.exports = function (grunt) {
         configFile: 'test/karma.conf.js',
         singleRun: true
       }
+    },
+
+    //appcache settings
+    appcache: {
+      options: {
+        basePath: 'web'
+      },
+      all: {
+        dest: 'web/manifest.appcache',
+        cache: {
+          patterns: [
+            'web/**/*',
+            '!web/php/**/*'
+          ]
+        },
+        network: '*'
+      }
     }
   });
 
@@ -430,7 +447,8 @@ module.exports = function (grunt) {
     'uglify',
     'filerev',
     'usemin',
-    'htmlmin'
+    'htmlmin',
+    'appcache'
   ]);
 
   grunt.registerTask('default', [

--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js">
+<html class="no-js" manifest="manifest.appcache">
 <head>
     <title>Calendar</title>
     <link rel="icon" href="images/favicon.png">

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "^0.4.1",
+    "grunt-appcache": "^0.1.8",
     "grunt-autoprefixer": "^0.7.3",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",


### PR DESCRIPTION
Part 1 of https://github.com/UltraSoftcore/Match-Calendar/issues/44. Generates a manifest.appcache on build that allows the client to cache the entire application on load for use as an offline app. Saves ~1.4MB of files into the offline cache and won't re-request the files until the appcache changes. Client only checks for updated items if an update happens to the manifest.appcache file (happens on every build). API calls will not work in offline mode (that is part 2 of offlining the app)
