### PR TITLE
Clean up time references

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -5,7 +5,7 @@ angular.module('MatchCalendarApp', ['ui.bootstrap', 'LocalForageModule', 'ngSani
 
     .run(function($rootScope, $localForage, DateTimeService, editableOptions, $q, Migrations) {
         editableOptions.theme = 'bs3';
-        $rootScope.timeOffset = DateTimeService;
+        $rootScope.T = DateTimeService;
         DateTimeService.resync();
 
         $rootScope.appSchemaVersion = 1;

--- a/app/components/Generator/generator.html
+++ b/app/components/Generator/generator.html
@@ -3,7 +3,7 @@
         <div class="col-md-6">
             <div class="panel panel-default">
                 <div class="panel-heading">
-                    <h3 class="panel-title">Opens: </h3><span ng-bind="simpleUtcOpens"></span>
+                    <h3 class="panel-title">Opens: </h3><span ng-bind="T.format(T.formats.GENERATOR_SIMPLE, opens.utc(), true)"></span>
                 </div>
                 <div class="panel-body">
                     <p class="help-block">Time game will open (in your selected timezone)</p>
@@ -14,7 +14,7 @@
         <div class="col-md-6">
             <div class="panel panel-default">
                 <div class="panel-heading">
-                    <h3 class="panel-title">Starts: </h3><span ng-bind="simpleUtcStarts"></span>
+                    <h3 class="panel-title">Starts: </h3><span ng-bind="T.format(T.formats.GENERATOR_SIMPLE, starts.utc(), true)"></span>
                 </div>
                 <div class="panel-body">
                     <p class="help-block">Time game will start (in your selected timezone)</p>

--- a/app/components/Generator/headergenerator.js
+++ b/app/components/Generator/headergenerator.js
@@ -29,11 +29,9 @@ angular.module('MatchCalendarApp')
 
         $scope.$watch('opens', function (newValue) {
             $scope.generated.opens = newValue.utc().format('YYYY-MM-DDTHH:mm:ssZ');
-            $scope.simpleUtcOpens = newValue.utc().format('YYYY-MM-DD HH:mm UTC');
         });
         $scope.$watch('starts', function (newValue) {
             $scope.generated.starts = newValue.utc().format('YYYY-MM-DDTHH:mm:ssZ');
-            $scope.simpleUtcStarts = newValue.utc().format('YYYY-MM-DD HH:mm UTC');
         });
         $scope.$watch('settings.generator.address', function (newValue) {
             $scope.generated.address = newValue.replace(/\[/g, '&#91;').replace(/\]/g, '&#93;');
@@ -49,6 +47,6 @@ angular.module('MatchCalendarApp')
             $scope.generatedLink = '[' + JSON.stringify(newValue) + '](/matchpost)';
         }, true);
 
-        $scope.opens = $scope.timeOffset.currentTime();
-        $scope.starts = $scope.timeOffset.currentTime();
+        $scope.opens = $scope.T.currentTime();
+        $scope.starts = $scope.T.currentTime();
     });

--- a/app/components/Generic/application.js
+++ b/app/components/Generic/application.js
@@ -44,7 +44,7 @@ angular.module('MatchCalendarApp')
             RedditPostsService.query($scope.settings.subreddits).then(function (data) {
                 $scope.posts.posts = data;
                 $scope.posts.updatingPosts = false;
-                $scope.posts.lastUpdated = $scope.timeOffset.currentTime();
+                $scope.posts.lastUpdated = $scope.T.currentTime();
                 angular.forEach($scope.posts.posts, function (element) {
                     element.region = element.region || 'Unknown';
                     if (!angular.isDefined($scope.posts.regions[element.region])) {
@@ -108,9 +108,9 @@ angular.module('MatchCalendarApp')
             });
         };
 
-        $scope.currentTime = $scope.timeOffset.currentTime();
+        $scope.currentTime = $scope.T.currentTime();
         $scope.clockTick = function () {
-            $scope.currentTime = $scope.timeOffset.currentTime();
+            $scope.currentTime = $scope.T.currentTime();
             if (HtmlNotifications.currentPermission() === 'granted') {
                 if ($scope.posts.posts.length !== 0) {
                     for (var pid in $scope.settings.notifyFor) {

--- a/app/components/PostList/list.html
+++ b/app/components/PostList/list.html
@@ -22,7 +22,7 @@
                     <b class="refresh-icon" ng-click="updatePosts()">
                         <i class="fa fa-refresh" ng-class="{'fa-spin': posts.updatingPosts}"></i> Refresh
                         <small class="center-block">
-                            Last Updated: <small class="last-updated" ng-bind="posts.lastUpdated.tz(settings.timeZone).format(settings.timeFormat == '24h' ? 'HH:mm:ss' : 'hh:mm:ss a')"></small>
+                            Last Updated: <small class="last-updated" ng-bind="T.format(T.formats.HEADER, posts.lastUpdated)"></small>
                         </small>
                     </b>
                 </div>
@@ -51,12 +51,12 @@
                 <div class="row text-center" ng-attr-id="{{ 'post-' + post.id }}">
                     <div class="col-lg-2 col-xs-12 text-center text-right-lg">
                         <span class="abs-game-starts" tooltip="Time starts">
-                            <b ng-bind="post.starts == null ? 'Unparsed' : post.starts.tz(settings.timeZone).format(settings.timeFormat == '24h' ? 'MMM DD - HH:mm' : 'MMM DD - hh:mm a')"></b>
+                            <b ng-bind="T.format(T.formats.POST_HEADER, post.starts)"></b>
                             &nbsp;<i class="fa fa-calendar" ng-click="toggleNotifications(post.id); $event.stopPropagation()" ng-class="{notifications: willNotify(post.id)}"></i>
                         </span>
                         <span class="server-region visible-lg-block visible-xs-inline visible-md-inline visible-sm-inline" tooltip="Server Region">
                             &nbsp;
-                            <small ng-bind="post.region == null ? 'Unknown' : post.region"></small>
+                            <small ng-bind="post.region || 'Unknown'"></small>
                             <i class="fa fa-globe"></i>
                         </span>
                         <div class="divider visible-xs visible-md visible-sm hidden-lg"></div>
@@ -68,8 +68,8 @@
                         </div>
                         <div class="visible-lg-block">
                             <small class="time-posted" tooltip="Time posted">
-                                <i class="fa fa-reply fa-rotate-180"></i> <span ng-bind="post.posted.from(timeOffset.currentTime())"></span>
-                                - <span ng-bind="post.starts == null ? 'N/A' : post.posted.from(post.starts, true)"></span> in advance.
+                                <i class="fa fa-reply fa-rotate-180"></i> <span ng-bind="post.posted.from(T.currentTime())"></span>
+                                - <span ng-bind="post.posted.from(post.starts, true)"></span> in advance.
                             </small>
                         </div>
                         <div class="divider visible-xs visible-md visible-sm hidden-lg"></div>
@@ -90,10 +90,10 @@
                     </div>
                     <div class="col-lg-2 text-left-lg text-center col-xs-12">
                         <span tooltip="Opens" class="game-opens">
-                            <i class="fa fa-clock-o"></i> <small ng-bind="post.opens != null ? post.opens.from(timeOffset.currentTime()) : 'Unknown'"></small>
+                            <i class="fa fa-clock-o"></i> <small ng-bind="post.opens.from(T.currentTime()) || 'Unknown'"></small>
                         </span>
                         <span tooltip="Starts" class="game-starts visible-lg-block visible-xs-inline visible-md-inline visible-sm-inline">
-                            <i class="fa fa-caret-square-o-right"></i> <small ng-bind="post.starts != null ? post.starts.from(timeOffset.currentTime()) : 'Unknown'"></small>
+                            <i class="fa fa-caret-square-o-right"></i> <small ng-bind="post.starts.from(T.currentTime()) || 'Unknown'"></small>
                         </span>
                     </div>
                 </div>

--- a/app/components/PostList/matchpost.js
+++ b/app/components/PostList/matchpost.js
@@ -107,7 +107,7 @@ angular.module('MatchCalendarApp')
             if (post.starts !== null) {
                 if (!post.starts.isValid()) {
                     post.starts = null;
-                } else if (post.starts.diff($rootScope.timeOffset.currentTime()) < 0) {
+                } else if (post.starts.diff($rootScope.T.currentTime()) < 0) {
                     //if it's in the past don't show it at all
                     return null;
                 }

--- a/app/components/Time/datetimeservice.js
+++ b/app/components/Time/datetimeservice.js
@@ -8,8 +8,26 @@
  * Factory in the MatchCalendarApp.
  */
 angular.module('MatchCalendarApp')
-    .factory('DateTimeService', ['$http', function ($http) {
+    .factory('DateTimeService', function ($http, $rootScope) {
         var resyncURL = 'api/sync';
+
+        //header
+        //currentTime.tz(settings.timeZone).format(settings.timeFormat == &apos;24h&apos; ? &apos;HH:mm&apos; : &apos;hh:mm a&apos;)
+
+        var formats = {
+            TITLE: function() {
+                return $rootScope.settings.timeFormat == '24h' ? 'HH:mm' : 'hh:mm a';
+            },
+            HEADER: function() {
+                return $rootScope.settings.timeFormat == '24h' ? 'HH:mm:ss' : 'hh:mm:ss a';
+            },
+            POST_HEADER: function() {
+                return $rootScope.settings.timeFormat == '24h' ? 'MMM DD - HH:mm' : 'MMM DD - hh:mm a';
+            },
+            GENERATOR_SIMPLE: function() {
+                return 'YYYY-MM-DD HH:mm Z';
+            }
+        };
 
         return {
             synced: false,
@@ -30,6 +48,22 @@ angular.module('MatchCalendarApp')
                     current.add('ms', this.offset);
                 }
                 return current;
-            }
+            },
+            /**
+             * Format the time
+             *
+             * @param format the format to use, function that returns the string
+             * @param time the time to format, default current time
+             * @param keeptz true means keep existing timezone, false means use selected
+             * @returns {*}
+             */
+            format: function(format, time, keeptz) {
+                time = time || this.currentTime();
+                if(!keeptz) {
+                    time.tz($rootScope.settings.timeZone);
+                }
+                return time.format(format());
+            },
+            formats: formats
         };
-    }]);
+    });

--- a/app/index.html
+++ b/app/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="no-js" manifest="manifest.appcache" ng-app="MatchCalendarApp" ng-controller="ApplicationCtrl">
 <head>
-    <title ng-bind="currentTime.tz(settings.timeZone).format(settings.timeFormat == &apos;24h&apos; ? &apos;HH:mm&apos; : &apos;hh:mm a&apos;) + &apos; - Calendar&apos;">Calendar</title>
+    <title ng-bind="T.format(T.formats.TITLE) + &apos; - Calendar&apos;">Calendar</title>
     <link rel="icon" href="images/favicon.png">
 
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
@@ -57,8 +57,8 @@
     <div class="col-sm-6 clock-bar-center">
         <div class="row">
             <div class="col-xs-12 clock-bar-time">
-                <strong ng-class="{unsynced: !timeOffset.synced}" ng-bind="currentTime.tz(settings.timeZone).format(settings.timeFormat == &apos;24h&apos; ? &apos;HH:mm:ss&apos; : &apos;hh:mm:ss a&apos;)"></strong>
-                <i class="fa fa-info-circle" ng-show="!timeOffset.synced" tooltip="The time has not been synced with the server yet. If this persists try reloading the page"></i>
+                <strong ng-class="{unsynced: !T.synced}" ng-bind="T.format(T.formats.HEADER)"></strong>
+                <i class="fa fa-info-circle" ng-show="!T.synced" tooltip="The time has not been synced with the server yet. If this persists try reloading the page"></i>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
Move the formatting of time strings into the service to cleanup templates a little bit. Templates don't need to know what time format/zone the app is in generally.

Changes $rootScope.timeOffset to $rootScope.T
