### PR TITLE
fix(regions): Only show regions that are currently in the list but still...

### DIFF
--- a/app/components/PostList/Posts.js
+++ b/app/components/PostList/Posts.js
@@ -14,6 +14,7 @@ angular.module('MatchCalendarApp')
         $scope.posts = [];
         $scope.lastUpdated = 0;
         $scope.regions = {};
+        $scope.currentRegions = [];
         $localForage.bind($scope, 'lastUpdated');
         $localForage.bind($scope, 'regions');
 
@@ -24,12 +25,17 @@ angular.module('MatchCalendarApp')
             RedditPostsService.query($rootScope.settings.subreddits).then(function (data) {
                 $scope.posts = data;
                 $scope.updating = false;
+                $scope.currentRegions = [];
                 angular.forEach($scope.posts, function (element) {
                     element.region = element.region || 'Unknown';
+                    if($scope.currentRegions.indexOf(element.region) === -1) {
+                        $scope.currentRegions.push(element.region);
+                    }
                     if (!angular.isDefined($scope.regions[element.region])) {
                         $scope.regions[element.region] = true;
                     }
                 });
+
                 $scope.lastUpdated = $rootScope.T.currentTime().unix();
                 $rootScope.$broadcast('postsUpdated', $scope.posts);
                 def.resolve();

--- a/app/components/PostList/list.html
+++ b/app/components/PostList/list.html
@@ -10,9 +10,9 @@
                     </div>
                     <div class="center-block text-left-lg">
                         <b>Regions:</b>
-                        <span ng-repeat="(region, x) in posts.regions">
+                        <span bindonce refresh-on="'postsUpdated'" ng-repeat="region in posts.currentRegions">
                             <label>
-                                <small ng-bind="region"></small>
+                                <small bo-text="region"></small>
                                 <input type="checkbox" ng-model="posts.regions[region]">
                             </label>
                         </span>


### PR DESCRIPTION
... store the settings for seen regions

Enables storing enabled status for regions that arn't in the current list.
You can untick 'Unknown' and it will remember the setting for the next time 'Unknown' comes up.
