### PR TITLE
Fix copying the address not showing 'copied!' briefly

### DIFF
--- a/app/components/PostList/PostList.js
+++ b/app/components/PostList/PostList.js
@@ -40,8 +40,10 @@ angular.module('MatchCalendarApp')
             }
             var saved = post.address;
             post.address = 'Copied!';
+            $scope.$broadcast('regionCopyChange');
             $timeout(function () {
                 post.address = saved;
+                $scope.$broadcast('regionCopyChange');
             }, 2000);
         };
 

--- a/app/components/PostList/list.html
+++ b/app/components/PostList/list.html
@@ -88,7 +88,7 @@
                         <span bo-show="post.address !== null">
                             <span class="server-address visible-xs-inline visible-md-inline visible-sm-inline visible-lg-block" tooltip="Server address" ng-click="$event.stopPropagation()">
                                 <span clip-copy="post.address" clip-click="triggerCopiedMessage(post)">
-                                    <small bo-text="post.address"></small> <i class="fa fa-cubes"></i>
+                                    <small bindonce refresh-on="'regionCopyChange'" bo-text="post.address"></small> <i class="fa fa-cubes"></i>
                                 </span>
                             </span>
                         </span>


### PR DESCRIPTION
Added a new event whenever the address is changed via copying to update the view

BREAK: Will probably break changing displayed region on loading of updated data from Reddit (i.e. load a post, someone then edits the post to change the region -> match calendar still shows the original. Page refresh will show the correct one. Not confirmed, very edge case, much wow
